### PR TITLE
fix: resolve console warnings for Radix UI and duplicate React keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
-    "@radix-ui/react-popover": "^1.1.14",
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-portal": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
         specifier: ^2.1.16
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-popover':
-        specifier: ^1.1.14
+        specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-portal':
         specifier: ^1.1.8

--- a/src/components/TaskItem.tsx
+++ b/src/components/TaskItem.tsx
@@ -539,9 +539,9 @@ export const TaskItem: React.FC<TaskItemProps> = ({ task, dateValidation }) => {
               <span className="capitalize">Recurring</span>
             </div>
           )}
-          {task.tags.map((tag) => (
+          {task.tags.map((tag, index) => (
             <TagBadge
-              key={tag.id}
+              key={`${task.id}-tag-${index}`}
               tag={tag}
               task={task}
               onUpdate={onUpdateTask}


### PR DESCRIPTION
## Summary

- Fix duplicate React key warning when rendering task tags by using composite key `${task.id}-tag-${index}` instead of `tag.id`
- Update `@radix-ui/react-popover` to latest version

## Problem

When external systems (like Obsidian) provide tasks with tags where `tag.id` equals the tag name (e.g., `#TODO`), React shows duplicate key warnings because multiple tasks can share the same tag.

## Solution

Use array index combined with task ID to ensure key uniqueness: `${task.id}-tag-${index}`

## Note on Radix UI CSS Deprecation

The CSS deprecation warnings (`Custom state pseudo classes have been changed from ":--radix-*" to ":state(radix-*)"`) are a **known upstream issue** in Radix UI. The packages are already at their latest versions. This will be resolved when Radix releases an update with the new CSS syntax.

## Test Plan

- [x] Type-check passes
- [x] Lint passes
- [ ] Verify no duplicate key warnings appear in console when multiple tasks have the same tag

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)