### PR TITLE
feat: IntersectionObserver lazy rendering for large task lists

### DIFF
--- a/docs/plans/2026-02-12-virtualization-design.md
+++ b/docs/plans/2026-02-12-virtualization-design.md
@@ -1,0 +1,78 @@
+# Virtualization Design — IntersectionObserver Lazy Sections
+
+**Issue:** #24
+**Date:** 2026-02-12
+**Status:** Approved
+
+## Problem
+
+When a vault has thousands of tasks, the component library renders all TaskItems upfront, causing poor performance. Hundreds of DaySections each rendering multiple TaskItems creates thousands of DOM nodes.
+
+## Approach: IntersectionObserver Lazy Sections
+
+Use the browser's IntersectionObserver API to only render TaskItems for sections near the viewport. Section headers always render (lightweight). Zero new dependencies.
+
+### Why not @tanstack/virtual or react-virtuoso?
+
+- Thousands of tasks is the rare extreme case, not the norm
+- The nested Year → Day → Task hierarchy would need flattening
+- Framer Motion animations would be lost or degraded
+- IntersectionObserver preserves the existing architecture and all animations
+
+## Design
+
+### New: `useLazyRender` hook
+
+```typescript
+// src/hooks/useLazyRender.ts
+function useLazyRender(estimatedHeight: number, rootMargin?: string): {
+  containerRef: RefObject<HTMLDivElement>;
+  contentRef: RefObject<HTMLDivElement>;
+  isNearViewport: boolean;
+  placeholderHeight: number;
+}
+```
+
+**Behavior:**
+- `isNearViewport` starts `false`; observer fires on mount and sets `true` for sections within range
+- `rootMargin` defaults to `"500px 0px"` — sections pre-render 500px before becoming visible
+- When a section leaves the viewport, its measured height is cached (prevents scroll jumps)
+- Before any measurement, uses `estimatedHeight` (task count × ~52px)
+
+### Component changes
+
+**DaySection** — Add `lazy?: boolean` prop (default `true`):
+- When `lazy=true`: wrap task list with `useLazyRender`, render placeholder when off-screen
+- When `lazy=false`: render all tasks immediately (used for Today section)
+- Section headers, collapse/expand, sticky behavior: untouched
+
+**BacklogSection** — Wrap task list with `useLazyRender`.
+
+**TodoList** — Pass `lazy={false}` to the Today `<DaySection>`.
+
+### What's preserved
+
+- All Framer Motion animations (collapse/expand, add/delete, hover/click)
+- Collapsible section state (section component stays mounted, only TaskItems unmount)
+- Sticky day headers
+- Existing component hierarchy and API
+
+### Edge cases
+
+- **Task count changes while off-screen**: estimated height updates; fresh tasks render on re-entry
+- **Rapid scrolling**: 500px rootMargin provides buffer; observer is browser-native (efficient)
+- **Collapsed sections**: collapse state preserved (lives in DaySection useState, not in TaskItems)
+- **Focus mode**: only Today section visible, no virtualization needed
+- **Filter changes**: task list recalculates in TodoList useMemo, DaySections re-render naturally
+
+## Files
+
+| File | Change |
+|------|--------|
+| `src/hooks/useLazyRender.ts` | **New** — IntersectionObserver hook |
+| `src/components/DaySection.tsx` | Add `lazy` prop, wrap task list |
+| `src/components/BacklogSection.tsx` | Wrap task list |
+| `src/components/TodoList.tsx` | Pass `lazy={false}` to Today section |
+| `src/hooks/index.ts` | Export `useLazyRender` |
+
+No changes to TaskItem, YearSection, TasksTimelineApp, types, or contexts.

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -102,7 +102,7 @@ export const TodoList: React.FC<TodoListProps> = ({ className }) => {
               : ""}
           </span>
         </div>
-        <DaySection group={todayGroup} />
+        <DaySection group={todayGroup} lazy={false} />
       </div>
 
       {/* Timeline - Hidden in Focus Mode */}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -15,3 +15,5 @@ export { useVoiceInput } from "./useVoiceInput";
 export { usePortalContainer } from "./usePortalContainer";
 
 export { useDateHelpers } from "./useDateHelpers";
+
+export { useLazyRender } from "./useLazyRender";

--- a/src/hooks/useLazyRender.ts
+++ b/src/hooks/useLazyRender.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+
+interface UseLazyRenderOptions {
+  /** CSS rootMargin for IntersectionObserver (default: "500px 0px") */
+  rootMargin?: string;
+  /** Whether lazy rendering is enabled (default: true) */
+  enabled?: boolean;
+}
+
+interface UseLazyRenderResult {
+  /** Attach to the outer container that the observer watches */
+  containerRef: React.RefCallback<HTMLDivElement>;
+  /** Attach to the inner content wrapper to measure its height */
+  contentRef: React.RefCallback<HTMLDivElement>;
+  /** Whether the section is near the viewport and should render content */
+  isNearViewport: boolean;
+  /** Height for the placeholder when content is not rendered */
+  placeholderHeight: number;
+}
+
+const ESTIMATED_ITEM_HEIGHT = 52;
+
+/**
+ * Hook that uses IntersectionObserver to lazily render content
+ * only when it's near the viewport. Returns a placeholder height
+ * to prevent scroll jumps when content unmounts.
+ */
+export function useLazyRender(
+  itemCount: number,
+  options: UseLazyRenderOptions = {},
+): UseLazyRenderResult {
+  const { rootMargin = "500px 0px", enabled = true } = options,
+    [isNearViewport, setIsNearViewport] = useState(!enabled),
+    [measuredHeight, setMeasuredHeight] = useState<number | null>(null),
+    containerElRef = useRef<HTMLDivElement | null>(null),
+    contentElRef = useRef<HTMLDivElement | null>(null),
+    observerRef = useRef<IntersectionObserver | null>(null);
+
+  // Estimated height based on item count
+  const estimatedHeight = itemCount * ESTIMATED_ITEM_HEIGHT;
+
+  // Cache content height before it unmounts
+  const cacheHeight = useCallback(() => {
+    if (contentElRef.current) {
+      setMeasuredHeight(contentElRef.current.offsetHeight);
+    }
+  }, []);
+
+  // Set up IntersectionObserver
+  useEffect(() => {
+    if (!enabled) return;
+
+    const el = containerElRef.current;
+    if (!el) return;
+
+    observerRef.current = new IntersectionObserver(
+      ([entry]) => {
+        const isNear = entry.isIntersecting;
+        if (!isNear) {
+          cacheHeight();
+        }
+        setIsNearViewport(isNear);
+      },
+      { rootMargin },
+    );
+
+    observerRef.current.observe(el);
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [enabled, rootMargin, cacheHeight]);
+
+  // Ref callbacks for stable element tracking
+  const containerRef = useCallback((node: HTMLDivElement | null) => {
+    containerElRef.current = node;
+  }, []);
+
+  const contentRef = useCallback((node: HTMLDivElement | null) => {
+    contentElRef.current = node;
+  }, []);
+
+  return {
+    containerRef,
+    contentRef,
+    isNearViewport,
+    placeholderHeight: measuredHeight ?? estimatedHeight,
+  };
+}

--- a/src/stories/Sections/BacklogSection.stories.tsx
+++ b/src/stories/Sections/BacklogSection.stories.tsx
@@ -12,6 +12,7 @@ import { delay } from "../test-utils";
 // Extend component props with story-specific args for decorator usage
 interface BacklogSectionStoryArgs {
   tasks: Task[];
+  lazy?: boolean;
   settings?: ReturnType<typeof settingsBuilder.default>;
 }
 
@@ -19,6 +20,9 @@ const meta: Meta<BacklogSectionStoryArgs> = {
   title: "Sections/BacklogSection",
   component: BacklogSection as unknown as React.FC<BacklogSectionStoryArgs>,
   tags: ["autodocs"],
+  args: {
+    lazy: false,
+  },
   parameters: {
     layout: "fullscreen",
   },

--- a/src/stories/Sections/DaySection.stories.tsx
+++ b/src/stories/Sections/DaySection.stories.tsx
@@ -18,6 +18,7 @@ import { delay } from "../test-utils";
 // Extend component props with story-specific args for decorator usage
 interface DaySectionStoryArgs {
   group: DayGroup;
+  lazy?: boolean;
   settings?: ReturnType<typeof settingsBuilder.default>;
   isAiMode?: boolean;
   availableCategories?: string[];
@@ -27,6 +28,9 @@ const meta: Meta<DaySectionStoryArgs> = {
   title: "Sections/DaySection",
   component: DaySection as unknown as React.FC<DaySectionStoryArgs>,
   tags: ["autodocs"],
+  args: {
+    lazy: false,
+  },
   parameters: {
     layout: "fullscreen",
   },


### PR DESCRIPTION
## Summary

- Adds `useLazyRender` hook using IntersectionObserver to defer rendering of off-screen timeline sections
- DaySection and BacklogSection only render their TaskItems when within 500px of the viewport; distant sections show height-preserving placeholders
- Today section always renders immediately (`lazy={false}`)
- Tested with 550+ task datasets in Storybook — zero new test regressions

## Design

See `docs/plans/2026-02-12-virtualization-design.md` for the full design document.

**Key decisions:**
- IntersectionObserver over `@tanstack/virtual` to preserve Framer Motion animations and avoid new dependencies
- Section-level granularity (not per-task) for simplicity and animation compatibility
- Height caching before unmount to prevent scroll position jumps

## Files changed

| File | Change |
|------|--------|
| `src/hooks/useLazyRender.ts` | New hook with IntersectionObserver, height caching, ref callbacks |
| `src/components/DaySection.tsx` | Added `lazy` prop, conditional rendering wrapper |
| `src/components/BacklogSection.tsx` | Added `lazy` prop, conditional rendering wrapper |
| `src/components/TodoList.tsx` | Pass `lazy={false}` to Today's DaySection |
| `src/hooks/index.ts` | Export new hook |
| `src/stories/Core/TodoList.stories.tsx` | Added LargeDatasetVirtualized (550 tasks) and LargeDatasetNoBacklog (300 tasks) stories |
| `src/stories/Sections/*.stories.tsx` | Set `lazy: false` in standalone section stories |

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm type-check` passes
- [x] Storybook interaction tests: 0 new regressions (42 pre-existing failures on master)
- [x] LargeDatasetVirtualized story renders 550 tasks with fewer than 550 DOM nodes
- [ ] Manual scroll test in Storybook LargeDatasetVirtualized story for smooth performance

Closes #24