### PR TITLE
feat: add missing settings UI for sound and input bar visibility

### DIFF
--- a/src/TasksTimelineApp.tsx
+++ b/src/TasksTimelineApp.tsx
@@ -89,7 +89,6 @@ const DEFAULT_SETTINGS: AppSettings = {
   totalTokenUsage: 0,
   defaultCategory: "General",
 
-  settingButtonOnInputBar: undefined,
   filters: {
     tags: [],
     categories: [],

--- a/src/components/settings/SettingsPageGeneral.tsx
+++ b/src/components/settings/SettingsPageGeneral.tsx
@@ -4,12 +4,54 @@ import { TypographySection } from "./TypographySection";
 import { ViewSection } from "./ViewSection";
 import { DATE_FORMATS } from "./ViewSectionConstants";
 import { useState } from "react";
+import { cn } from "@/utils";
+import { MotionSpan } from "../Motion";
+import { Icon } from "../Icon";
 
 interface SettingsPageGeneralProps {
   settings: AppSettings;
   onUpdateSettings: (s: AppSettings) => void;
   availableCategories: string[];
 }
+
+const INPUT_BAR_ITEMS = [
+  {
+    key: "settingButtonOnInputBar" as const,
+    label: "Settings Button",
+    description: "Show settings gear icon",
+    icon: "Settings" as const,
+  },
+  {
+    key: "tagsFilterOnInputBar" as const,
+    label: "Tags Filter",
+    description: "Show tags filter chips",
+    icon: "Tag" as const,
+  },
+  {
+    key: "categoriesFilterOnInputBar" as const,
+    label: "Categories Filter",
+    description: "Show categories filter chips",
+    icon: "Folder" as const,
+  },
+  {
+    key: "priorityFilterOnInputBar" as const,
+    label: "Priority Filter",
+    description: "Show priority filter chips",
+    icon: "Flag" as const,
+  },
+  {
+    key: "statusFilterOnInputBar" as const,
+    label: "Status Filter",
+    description: "Show status filter chips",
+    icon: "CircleDot" as const,
+  },
+  {
+    key: "sortOnInputBar" as const,
+    label: "Sort Control",
+    description: "Show sort options",
+    icon: "ArrowUpDown" as const,
+  },
+];
 
 export const SettingsPageGeneral = ({
   settings,
@@ -36,11 +78,28 @@ export const SettingsPageGeneral = ({
         ...settings,
         showProgressBar: !settings.showProgressBar,
       }),
+    toggleSound = () =>
+      onUpdateSettings({
+        ...settings,
+        soundEnabled: !settings.soundEnabled,
+      }),
     toggleDefaultFocus = () =>
       onUpdateSettings({
         ...settings,
         defaultFocusMode: !settings.defaultFocusMode,
       }),
+    toggleInputBarItem = (
+      key:
+        | "settingButtonOnInputBar"
+        | "tagsFilterOnInputBar"
+        | "categoriesFilterOnInputBar"
+        | "priorityFilterOnInputBar"
+        | "statusFilterOnInputBar"
+        | "sortOnInputBar",
+    ) => {
+      const current = settings[key] !== false;
+      onUpdateSettings({ ...settings, [key]: !current });
+    },
     toggleGroupingStrategy = (s: DateGroupBy) => {
       const current = settings.groupingStrategy,
         exists = current.includes(s);
@@ -87,6 +146,8 @@ export const SettingsPageGeneral = ({
             toggleRelativeDates={toggleRelativeDates}
             showProgressBar={settings.showProgressBar}
             toggleProgressBar={toggleProgressBar}
+            soundEnabled={settings.soundEnabled}
+            toggleSound={toggleSound}
             defaultFocusMode={settings.defaultFocusMode}
             toggleDefaultFocus={toggleDefaultFocus}
             dateFormat={settings.dateFormat}
@@ -99,6 +160,56 @@ export const SettingsPageGeneral = ({
             groupingStrategy={settings.groupingStrategy}
             toggleGroupingStrategy={toggleGroupingStrategy}
           />
+        </section>
+
+        {/* Input Bar */}
+        <section>
+          <h3 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-4 flex items-center gap-2">
+            <Icon name="PanelBottom" size={12} className="text-blue-500" />
+            Input Bar
+          </h3>
+          <div className="space-y-4">
+            {INPUT_BAR_ITEMS.map((item) => {
+              const isEnabled = settings[item.key] !== false;
+              return (
+                <div
+                  key={item.key}
+                  className="flex items-center justify-between"
+                >
+                  <div className="flex items-center gap-2.5">
+                    <Icon
+                      name={item.icon}
+                      size={14}
+                      className="text-slate-400"
+                    />
+                    <div className="flex flex-col">
+                      <span className="text-sm font-medium text-slate-700">
+                        {item.label}
+                      </span>
+                      <span className="text-xs text-slate-400">
+                        {item.description}
+                      </span>
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => toggleInputBarItem(item.key)}
+                    className={cn(
+                      "relative w-10 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400",
+                      isEnabled
+                        ? "bg-blue-500"
+                        : "bg-slate-200 dark:bg-slate-700",
+                    )}
+                  >
+                    <MotionSpan
+                      layout
+                      className="absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm block"
+                      animate={{ x: isEnabled ? 16 : 0 }}
+                    />
+                  </button>
+                </div>
+              );
+            })}
+          </div>
         </section>
       </div>
     </>

--- a/src/components/settings/ViewSection.tsx
+++ b/src/components/settings/ViewSection.tsx
@@ -11,6 +11,8 @@ interface ViewSectionProps {
   toggleRelativeDates: () => void;
   showProgressBar: boolean;
   toggleProgressBar: () => void;
+  soundEnabled: boolean;
+  toggleSound: () => void;
   defaultFocusMode: boolean;
   toggleDefaultFocus: () => void;
   dateFormat: string;
@@ -31,6 +33,8 @@ export const ViewSection = ({
   toggleRelativeDates,
   showProgressBar,
   toggleProgressBar,
+  soundEnabled,
+  toggleSound,
   defaultFocusMode,
   toggleDefaultFocus,
   setDateFormat,
@@ -115,6 +119,26 @@ export const ViewSection = ({
             layout
             className="absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm block"
             animate={{ x: showProgressBar ? 16 : 0 }}
+          />
+        </button>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col">
+          <span className="text-sm font-medium text-slate-700">Sound</span>
+          <span className="text-xs text-slate-400">Play sounds on actions</span>
+        </div>
+        <button
+          onClick={toggleSound}
+          className={cn(
+            "relative w-10 h-6 rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-blue-400",
+            soundEnabled ? "bg-blue-500" : "bg-slate-200 dark:bg-slate-700",
+          )}
+        >
+          <MotionSpan
+            layout
+            className="absolute top-1 left-1 w-4 h-4 bg-white rounded-full shadow-sm block"
+            animate={{ x: soundEnabled ? 16 : 0 }}
           />
         </button>
       </div>

--- a/src/stories/Settings/SettingsPageGeneral.stories.tsx
+++ b/src/stories/Settings/SettingsPageGeneral.stories.tsx
@@ -361,16 +361,68 @@ export const ToggleGroupingStrategy: Story = {
 };
 
 // ========================================
+// Sound Variants
+// ========================================
+
+export const SoundEnabled: Story = {
+  args: {
+    settings: settingsBuilder.withSound(),
+    onUpdateSettings: handleUpdateSettings,
+    availableCategories: ["Work", "Personal"],
+  },
+};
+
+export const SoundDisabled: Story = {
+  args: {
+    ...Default.args,
+    settings: {
+      ...settingsBuilder.default(),
+      soundEnabled: false,
+    },
+  },
+};
+
+// ========================================
+// Input Bar Variants
+// ========================================
+
+export const InputBarAllVisible: Story = {
+  args: {
+    ...Default.args,
+  },
+};
+
+export const InputBarAllHidden: Story = {
+  args: {
+    settings: settingsBuilder.minimalUI(),
+    onUpdateSettings: handleUpdateSettings,
+    availableCategories: ["Work", "Personal"],
+  },
+};
+
+export const InputBarPartiallyHidden: Story = {
+  args: {
+    settings: {
+      ...settingsBuilder.default(),
+      tagsFilterOnInputBar: false,
+      categoriesFilterOnInputBar: false,
+    },
+    onUpdateSettings: handleUpdateSettings,
+    availableCategories: ["Work", "Personal"],
+  },
+};
+
+// ========================================
 // Edge Cases
 // ========================================
 
 export const AllTogglesOff: Story = {
   args: {
     settings: {
-      ...settingsBuilder.default(),
+      ...settingsBuilder.minimalUI(),
       showCompleted: false,
-      showProgressBar: false,
       useRelativeDates: false,
+      soundEnabled: false,
       defaultFocusMode: false,
     },
     onUpdateSettings: handleUpdateSettings,
@@ -385,6 +437,7 @@ export const AllTogglesOn: Story = {
       showCompleted: true,
       showProgressBar: true,
       useRelativeDates: true,
+      soundEnabled: true,
       defaultFocusMode: true,
     },
     onUpdateSettings: handleUpdateSettings,

--- a/src/stories/fixtures/settings.ts
+++ b/src/stories/fixtures/settings.ts
@@ -207,6 +207,15 @@ export const settingsBuilder = {
   }),
 
   /**
+   * Sound enabled
+   */
+  withSound: (overrides?: Partial<AppSettings>): AppSettings => ({
+    ...settingsBuilder.default(),
+    soundEnabled: true,
+    ...overrides,
+  }),
+
+  /**
    * Voice input enabled
    */
   withVoiceInput: (overrides?: Partial<AppSettings>): AppSettings => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,12 +110,12 @@ export interface AppSettings {
   totalTokenUsage: number;
   defaultCategory: string;
 
-  settingButtonOnInputBar?: false;
-  tagsFilterOnInputBar?: false;
-  categoriesFilterOnInputBar?: false;
-  priorityFilterOnInputBar?: false;
-  statusFilterOnInputBar?: false;
-  sortOnInputBar?: false;
+  settingButtonOnInputBar?: boolean;
+  tagsFilterOnInputBar?: boolean;
+  categoriesFilterOnInputBar?: boolean;
+  priorityFilterOnInputBar?: boolean;
+  statusFilterOnInputBar?: boolean;
+  sortOnInputBar?: boolean;
 
   filters: FilterState;
   sort: SortState;


### PR DESCRIPTION
## Summary
- Fix `AppSettings` types: changed 6 `*OnInputBar` fields from `?: false` to `?: boolean` so they can be properly toggled
- Add **Sound** toggle to View Options section in General settings
- Add new **Input Bar** section in General settings with 6 toggles controlling visibility of: Settings Button, Tags Filter, Categories Filter, Priority Filter, Status Filter, Sort Control
- Remove redundant `settingButtonOnInputBar: undefined` from `DEFAULT_SETTINGS`
- Add `withSound()` builder to story fixtures
- Add 5 new Storybook stories: `SoundEnabled`, `SoundDisabled`, `InputBarAllVisible`, `InputBarAllHidden`, `InputBarPartiallyHidden`
- Update `AllTogglesOff` / `AllTogglesOn` stories to cover the new settings

## Test plan
- [ ] Run `pnpm lint` and `pnpm type-check` — both pass
- [ ] Open Storybook → Settings/SettingsPageGeneral — verify Sound toggle and Input Bar section render correctly
- [ ] Toggle each Input Bar item off → verify the corresponding element disappears in InputBar stories
- [ ] Verify `AllTogglesOff` and `AllTogglesOn` stories render with correct toggle states