### PR TITLE
fix: prevent AI agent tool loop and improve interaction dismissal

### DIFF
--- a/src/TasksTimelineApp.tsx
+++ b/src/TasksTimelineApp.tsx
@@ -357,7 +357,7 @@ export const TasksTimelineApp: React.FC<TasksTimelineAppProps> = ({
       [addToast],
     ),
     confirmToast = useCallback(
-      (title: string, description?: string): Promise<boolean> => {
+      (title: string, description?: string): Promise<boolean | null> => {
         return new Promise((resolve) => {
           const id = addToast({
             variant: "info",
@@ -370,7 +370,7 @@ export const TasksTimelineApp: React.FC<TasksTimelineAppProps> = ({
                 removeToast(id);
               },
               onCancel: () => {
-                resolve(false);
+                resolve(null);
                 removeToast(id);
               },
             },

--- a/src/capabilities/__tests__/tools/ask-user.test.ts
+++ b/src/capabilities/__tests__/tools/ask-user.test.ts
@@ -78,6 +78,25 @@ describe("ask_user tool", () => {
     });
   });
 
+  it("uses confirm mode when confirm=true, returns dismissed when cancelled", async () => {
+    mockConfirm.mockResolvedValue(null);
+    const ctx = makeContext({
+      confirm: mockConfirm as CapabilityContext["confirm"],
+    });
+
+    const tool = createAskUserTool(ctx);
+    const result = await tool.execute({
+      question: "Delete this task?",
+      confirm: true,
+    });
+
+    expect(result.result).toEqual({
+      question: "Delete this task?",
+      answer: null,
+      dismissed: true,
+    });
+  });
+
   // --- Select mode ---
 
   it("uses select mode when options provided, returns selected value", async () => {
@@ -120,6 +139,7 @@ describe("ask_user tool", () => {
     expect(result.result).toEqual({
       question: "Which database?",
       answer: null,
+      dismissed: true,
     });
   });
 
@@ -159,6 +179,7 @@ describe("ask_user tool", () => {
     expect(result.result).toEqual({
       question: "What name?",
       answer: null,
+      dismissed: true,
     });
   });
 

--- a/src/capabilities/system-prompt.ts
+++ b/src/capabilities/system-prompt.ts
@@ -84,9 +84,12 @@ When completing a recurring task with complete_task:
 ## Response Style
 
 - Be concise and helpful
-- Do NOT generate follow-up summary text after tool calls — use notify_user instead if you need to communicate something
+- You can communicate results in two ways:
+  1. **notify_user** — for rich formatted output (with body text, styling, detail blocks)
+  2. **Text response** — for simple messages (shown as a notification to the user)
+  Choose one per response — do not use both
 - If a request is ambiguous, use ask_user to get clarification
-- For statistics or plans, present results via notify_user with appropriate detail`;
+- If ask_user returns dismissed: true, the user chose to cancel. Do NOT retry the same question. Either proceed with a reasonable default or explain briefly why you cannot continue.`;
 
   if (developerPrompt) {
     prompt += `\n\n## Host Application Context\n${developerPrompt}`;

--- a/src/capabilities/tools/ask-user.ts
+++ b/src/capabilities/tools/ask-user.ts
@@ -59,6 +59,12 @@ export function createAskUserTool(ctx: CapabilityContext): ToolSpec {
         }
         const description = args.description as string | undefined;
         const confirmed = await ctx.confirm(question, description);
+        if (confirmed === null) {
+          return {
+            name: "ask_user",
+            result: { question, answer: null, dismissed: true },
+          };
+        }
         return {
           name: "ask_user",
           result: {
@@ -74,6 +80,12 @@ export function createAskUserTool(ctx: CapabilityContext): ToolSpec {
           return { name: "ask_user", result: unavailable };
         }
         const selected = await ctx.select(question, options);
+        if (selected === null) {
+          return {
+            name: "ask_user",
+            result: { question, answer: null, dismissed: true },
+          };
+        }
         return {
           name: "ask_user",
           result: {
@@ -88,6 +100,12 @@ export function createAskUserTool(ctx: CapabilityContext): ToolSpec {
         return { name: "ask_user", result: unavailable };
       }
       const answer = await ctx.prompt(question);
+      if (answer === null) {
+        return {
+          name: "ask_user",
+          result: { question, answer: null, dismissed: true },
+        };
+      }
       return {
         name: "ask_user",
         result: {

--- a/src/capabilities/tools/batch-update-tasks.ts
+++ b/src/capabilities/tools/batch-update-tasks.ts
@@ -118,7 +118,7 @@ export function createBatchUpdateTasksTool(ctx: CapabilityContext): ToolSpec {
           `Update ${filtered.length} task${filtered.length === 1 ? "" : "s"}?`,
           "This will apply changes to all matching tasks.",
         );
-        if (confirmed === false) {
+        if (confirmed === false || confirmed === null) {
           return {
             name: "batch_update_tasks",
             result: {

--- a/src/capabilities/tools/delete-task.ts
+++ b/src/capabilities/tools/delete-task.ts
@@ -30,7 +30,7 @@ export function createDeleteTaskTool(ctx: CapabilityContext): ToolSpec {
         `Delete "${existingTask.title}"?`,
         "This action cannot be undone.",
       );
-      if (confirmed === false) {
+      if (confirmed === false || confirmed === null) {
         return {
           name: "delete_task",
           result: { success: false, message: "Cancelled by user" },

--- a/src/capabilities/types.ts
+++ b/src/capabilities/types.ts
@@ -20,7 +20,7 @@ export interface CapabilityContext {
     detail?: DetailBlock[];
     timeout?: number | null;
   }): void;
-  confirm?(title: string, description?: string): Promise<boolean>;
+  confirm?(title: string, description?: string): Promise<boolean | null>;
   select?(
     title: string,
     options: { label: string; value: string }[],

--- a/src/hooks/useAIAgent.ts
+++ b/src/hooks/useAIAgent.ts
@@ -33,7 +33,7 @@ export const useAIAgent = (
   onTokenUsageUpdate?: (update: TokenUsageUpdate) => void,
   aiSystemPrompt?: string,
   onShowToast?: (toast: Omit<ToastMessage, "id">) => void,
-  onConfirm?: (title: string, description?: string) => Promise<boolean>,
+  onConfirm?: (title: string, description?: string) => Promise<boolean | null>,
   onSelect?: (
     title: string,
     options: { label: string; value: string }[],
@@ -190,6 +190,11 @@ export const useAIAgent = (
             totalTokens: tokenUsage.totalTokens,
           });
         }
+      }
+
+      // Show the model's final text response to the user
+      if (response.text?.trim()) {
+        onNotify("info", "AI", response.text.trim());
       }
     } catch (e) {
       logger.error("AI", "Agent processing failed", e);


### PR DESCRIPTION
## Summary

- **Fix repeated `notify_user` calls**: The system prompt forced models to always use `notify_user` instead of text responses, preventing the natural loop termination mechanism (model produces text → loop ends). Removed the prescriptive instruction and let models decide between `notify_user` (rich output) or text response (simple messages).
- **Show model's final text response**: After the tool loop ends, `response.text` is now shown to the user via `onNotify` instead of being silently discarded.
- **Add `dismissed: true` signal to `ask_user`**: All three modes (confirm/select/prompt) now return `{ answer: null, dismissed: true }` when the user cancels, with system prompt guidance to not retry dismissed interactions.
- **Distinguish confirm cancel from "No"**: Changed `confirm` callback type from `Promise<boolean>` to `Promise<boolean | null>` (`null` = dismissed, `false` = answered "No"). Updated `delete_task` and `batch_update_tasks` to handle both.

## Test plan

- [x] Existing capabilities tests pass (134/136 — 2 pre-existing date-related failures in `get-task-stats`)
- [x] New test added for confirm mode dismissal
- [x] Updated tests for select/prompt dismissal to expect `dismissed: true`
- [ ] Manual test: ask "what do I need to do today?" — should show one notification, not 4-5 repeated toasts
- [ ] Manual test: trigger `ask_user` interaction, cancel it — AI should not retry the question
- [ ] Manual test: `delete_task` confirmation cancel — deletion should not proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)